### PR TITLE
fix:修复使用 removeClippedSubviews 启用后，监听销毁资源引起视频无法正常播放

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -352,10 +352,7 @@ export struct RNCVideo {
         .align(Alignment.Center)
         .height(this.viewHeight)
         .width(this.viewWidth)
-        .onDisAppear(() => {
-          this.cancellationCallback()
-          this.playVideoModel.release();
-        })
+       
     }
   }
 }


### PR DESCRIPTION
fix:修复使用 removeClippedSubviews 启用后，监听销毁资源引起视频无法正常播放