### PR TITLE
fix:修复视频通过tabview 切换到首页 声音关闭，但是到另一个页面又有声音的问题

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -165,26 +165,33 @@ export struct RNCVideo {
     this.preparePlayer();
     this.registerCommandCallback();
 
+    this.callbackList.push(this.ctx.rnInstance.subscribeToLifecycleEvents("BACKGROUND", () => {
+       this.paused = true
+    })
+    )
+    this.callbackList.push(this.ctx.rnInstance.subscribeToLifecycleEvents("FOREGROUND", () => {
+      if (this.isUserPaused) {
+        this.paused = true
+        } else {
+        this.paused = false
+      }
+    })
+    )
+
     observer.on('navDestinationUpdate', (info) => {
       let navDestinationInfo = JSON.stringify(info)
       let navDestinationState = JSON.parse(navDestinationInfo) as NavDestinationState
       let state = navDestinationState.state
       let index = navDestinationState.index
       //index 是 Navigation 的页面值  video 当前的页面 == 1, state表示当前页面的状态,ON_HIDDEN 为页面隐藏,ON_SHOWN为页面显示
-      if(index == 1 && state == observer.NavDestinationState.ON_HIDDEN){
-        if (this.paused == true) {
-          this.isUserPaused = true
-        } else {
-          this.isUserPaused = false
+      if((index == 1 || index == 0) && state == observer.NavDestinationState.ON_HIDDEN){
           this.paused = true
-        }
       }
       if(index == 1 && state == observer.NavDestinationState.ON_SHOWN){
-        if(this.isUserPaused == true){
+        if (this.isUserPaused) {
           this.paused = true
-        }else {
+        } else {
           this.paused = false
-          this.isUserPaused = false
         }
 
       }
@@ -217,6 +224,8 @@ export struct RNCVideo {
   updatePropFromDesc(): void {
     this.muted = this.descriptor.props.muted
     this.paused = this.descriptor.props.paused
+    this.isUserPaused = this.descriptor.props.paused
+
     this.resizeMode = this.descriptor.props.resizeMode
     this.repeat = this.descriptor.props.repeat
     this.volume = this.descriptor.props.volume


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
修复视频通过tabview 切换到首页 声音关闭，但是到另一个页面又有声音的问题
解决思路：通过isUserPaused 这个值来判断是否是业务暂停视频，在视频页面不可见的时候暂停视频，在页面可见的时候判断是业务暂停还是video 不可见暂停，如果是业务已经暂停就不自己播放，如果是video 暂停video 可见的时候再恢复播放。
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)