### PR TITLE
fix:修复vmall的视频返回不播放问题

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -187,7 +187,7 @@ export struct RNCVideo {
       if((index == 1 || index == 0) && state == observer.NavDestinationState.ON_HIDDEN){
           this.paused = true
       }
-      if(index == 1 && state == observer.NavDestinationState.ON_SHOWN){
+      if(index == 1 || index == 0 && state == observer.NavDestinationState.ON_SHOWN){
         if (this.isUserPaused) {
           this.paused = true
         } else {

--- a/harmony/rn_video/src/main/ets/controller/VideoController.ets
+++ b/harmony/rn_video/src/main/ets/controller/VideoController.ets
@@ -164,6 +164,7 @@ export class VideoController {
           this.onVideoLoadStart(this.url);
           break;
         case AvplayerStatus.INITIALIZED:
+          this.onVideoLoadStart(this.url);
           this.avPlayer.surfaceId = String(this.surfaceId);
           this.avPlayer.prepare();
           this.status = CommonConstants.STATUS_INITIALIZED;


### PR DESCRIPTION
# Summary
修复在vmall项目中的发现页面有视频在播放的情况下跳转到本视频的放大播放在返回的时候视频不会播放问题


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


