### PR TITLE
fix: 修复react-native-video内存泄露问题

### DIFF
--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -52,7 +52,7 @@ const TAG: string = 'RNOH in ctrl'
 
 @Component
 export struct PlayPlayer {
-  private playVideoModel: VideoController = new VideoController();
+  private playVideoModel: VideoController | undefined = undefined;
   @Consume('srcVar') @Watch("onSrcChanged") src: string;// 视频src
   @Consume index: number;
   @Consume('mutedVar')  @Watch("onMutedChanged") muted: boolean ;
@@ -94,6 +94,11 @@ export struct PlayPlayer {
       this.playVideoModel.initPlayerThis(this as IPlayPlayer);
     }
   }
+  aboutToDisappear(): void {
+    if (this.playVideoModel) {
+       this.playVideoModel.release()
+    }
+  }
 
   // @Watch cb
   onChanged(propName: string) : void {
@@ -109,26 +114,36 @@ export struct PlayPlayer {
   onSrcChanged(propName: string) : void {
     Logger.debug(TAG, `onSrcChanged,srcout: ${JSON.stringify(this.src)}`);
     Logger.debug(TAG, `onSrcChanged,propName: ${JSON.stringify(propName)}`);
-    this.playVideoModel.switchVideo(this.src);
+    if (this.playVideoModel) {
+      this.playVideoModel.switchVideo(this.src);
+    }
   }
 
   onRepeatChanged(propName: string) : void {
     Logger.debug(TAG, `onRepeatChange, ${JSON.stringify(this.repeat)}`);
-    this.playVideoModel.switchRepeat(this.repeat);
+    if (this.playVideoModel) {
+      this.playVideoModel.switchRepeat(this.repeat);
+    }
   }
 
   onMutedChanged(propName: string) : void {
     Logger.debug(TAG, `onMutedChanged, ${JSON.stringify(this.muted)}`);
-    this.playVideoModel.switchMuted(this.muted);
+    if (this.playVideoModel) {
+      this.playVideoModel.switchMuted(this.muted);
+    }
   }
 
   onPausedChanged(propName: string) : void {
     Logger.debug(TAG, `onPausedChanged, ${JSON.stringify(this.paused)}`);
-    this.playVideoModel.switchPlayOrPause(this.paused);
+    if (this.playVideoModel) {
+      this.playVideoModel.switchPlayOrPause(this.paused);
+    }
   }
 
   setPreventsDisplaySleepDuringVideoPlaybackModifier(propName: string) : void {
-    this.playVideoModel.setPreventsDisplaySleepDuringVideoPlaybackModifier(this.preventsDisplaySleepDuringVideoPlayback);
+    if (this.playVideoModel) {
+      this.playVideoModel.setPreventsDisplaySleepDuringVideoPlaybackModifier(this.preventsDisplaySleepDuringVideoPlayback);
+    }
   }
 
   listenScreenDirection(): void  {
@@ -153,7 +168,9 @@ export struct PlayPlayer {
             surfaceHeight: PlayConstants.PLAY_PLAYER.SURFACE_HEIGHT
           });
           this.surfaceID = Number(this.xComponentController.getXComponentSurfaceId());
-          this.playVideoModel.firstPlay(this.index, this.src, this.surfaceID);
+          if (this.playVideoModel) {
+            this.playVideoModel.firstPlay(this.index, this.src, this.surfaceID);
+          }
         })
         .width(this.videoWidth)
         .height(this.videoHeight)


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
修复react-native-video 内存泄露问题。在PlayPlayer 模块 playVideoModel 初始化的时候第次都会new 一个新的VideoController 对象，实际上是会从RNCVideo 模块传一个过来，不需要new,通过修改为playVideoModel 定义为 VideoController | undefined 解决

## Test Plan

运行Video测试用例

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比

