### PR TITLE
fix:修复onVideoLoad方法入参类型问题

### DIFF
--- a/harmony/rn_video/src/main/ets/controller/VideoController.ets
+++ b/harmony/rn_video/src/main/ets/controller/VideoController.ets
@@ -164,7 +164,7 @@ export class VideoController {
           this.onVideoLoadStart(this.url);
           break;
         case AvplayerStatus.INITIALIZED:
-          this.onVideoLoadStart(this.url);
+          this.onVideoLoadStart(JSON.stringify(this.url));
           this.avPlayer.surfaceId = String(this.surfaceId);
           this.avPlayer.prepare();
           this.status = CommonConstants.STATUS_INITIALIZED;


### PR DESCRIPTION


# Summary


修复onVideoLoadStart方法在本地视频的并且是运行npm run dev的情况下入参类型问题
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


