### PR TITLE
fix:修改video的宽高改变之后视频被截取问题

### DIFF
--- a/harmony/rn_video/src/main/ets/controller/VideoController.ets
+++ b/harmony/rn_video/src/main/ets/controller/VideoController.ets
@@ -161,7 +161,7 @@ export class VideoController {
           }else{
             this.avPlayer.fdSrc = this.url;
           }
-          this.onVideoLoadStart(this.url);
+          this.onVideoLoadStart(JSON.stringify(this.url));
           break;
         case AvplayerStatus.INITIALIZED:
           this.onVideoLoadStart(JSON.stringify(this.url));

--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -61,6 +61,8 @@ export struct PlayPlayer {
   @Consume('volumeVar') @Watch("onChanged") volume: number;
   @Consume('resizeModeVar') @Watch("onChanged") resizeMode:string;
   @Consume('disableFocusVar') @Watch("onChanged") disableFocus: boolean;
+  @Consume @Watch("onChanged") changedViewWidth: number;
+  @Consume @Watch("onChanged") changedViewHeight: number;
   @Consume('preventsDisplaySleepDuringVideoPlaybackVar') @Watch("setPreventsDisplaySleepDuringVideoPlaybackModifier") preventsDisplaySleepDuringVideoPlayback: boolean;
 
   @State bright: number = PlayConstants.PLAY_PAGE.BRIGHT;
@@ -79,10 +81,7 @@ export struct PlayPlayer {
 
   viewWidth: number = 0;
   viewHeight: number = 0;
-  @Consume
-  changedViewWidth: number;
-  @Consume
-  changedViewHeight: number;
+
 
   private orientationChange: boolean = true;
 


### PR DESCRIPTION


# Summary
修改video的宽高改变之后视频被截取问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

