### PR TITLE
fix:修改react-native-video的本地视频暂停在播放是重头播放问题

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -35,11 +35,7 @@ import { PlayConstants } from './common/constants/PlayConstants';
 import { CommonConstants, ResizeMode } from './common/constants/CommonConstants';
 import Logger from './common/util/Logger';
 import { display } from '@kit.ArkUI';
-import fs from '@ohos.file.fs';
 import observer from '@ohos.arkui.observer';
-import { UIContext } from '@ohos.arkui.UIContext';
-function callBackFunc(info: observer.RouterPageInfo) {}
-
 
 interface NavDestinationState {
   navigationId: string
@@ -67,7 +63,6 @@ class RNCVideoSrc  {
 
 export interface RNCVideoProps extends ViewBaseProps {
   src: RNCVideoSrc
-  // srcType: string
   paused: boolean
   resizeMode: string
   muted: boolean
@@ -111,10 +106,8 @@ export struct RNCVideo {
 
   private playVideoModel: VideoController = new VideoController();
 
-  srcParam: string = '';/*外部传入参数src*/
-  @Provide('srcVar') src: string | media.AVFileDescriptor = '';/*最终avplayer认识的 字符串*/
+  @Provide('srcVar') srcParam: string | media.AVFileDescriptor = '';/*最终avplayer认识的 字符串*/
   @Provide index: number = 0;
-  @Provide type: number = CommonConstants.TYPE_LOCAL ;//TODO:luoxf 修改td
   @Provide('mutedVar') muted: boolean = false;
   @Provide('repeatVar') repeat: boolean = false;
   @Provide('pausedVar') paused: boolean = false;
@@ -146,7 +139,6 @@ export struct RNCVideo {
         this.descriptor = (newDescriptor as VideoViewDescriptor);
         /*------ 当RN侧属性props有更改 -------*/
         this.updatePropFromDesc();
-        this.preparePlayer();
         this.videoWidth = this.viewWidth;
 
         if(display.getDefaultDisplaySync().orientation == 0 || display.getDefaultDisplaySync().orientation == 2){
@@ -158,7 +150,6 @@ export struct RNCVideo {
     this.playVideoModel.initPlayPageThis(this as IRNCVideo);
     /*------ 初始化 -------*/
     this.updatePropFromDesc();
-    this.preparePlayer();
     this.registerCommandCallback();
 
     this.callbackList.push(this.ctx.rnInstance.subscribeToLifecycleEvents("BACKGROUND", () => {
@@ -207,9 +198,6 @@ export struct RNCVideo {
         this.tag,
         (command, args:(string|number)[]) => {
           if (command === RNC_VIDEO_SEEK) {
-            Logger.debug(TAG, `seek,  ${JSON.stringify(args)}`);
-            Logger.debug(TAG, `seek,  time: ${args[0]}`);
-            Logger.debug(TAG, `seek,  tolerance: ${args[1]}`);
             this.playVideoModel.setSeekTime(Number(args[0]));
           }
       }))
@@ -342,23 +330,7 @@ export struct RNCVideo {
   }
 
   async getFd(): Promise<void> {
-    Logger.debug(TAG, `getFd, ${(this.src)}`);
-  }
-
-  async preparePlayer(): Promise<void> {
-    if (this.srcParam.startsWith('http')) {
-      this.type = CommonConstants.TYPE_INTERNET
-      this.src = this.srcParam
-    } else if(this.srcParam.startsWith('asset')) {
-      const fileUrl = this.srcParam.split('//')[1];
-      let fileDescriptor = await getContext(this).resourceManager.getRawFd(`assets/${fileUrl}`);
-      this.src = fileDescriptor;
-    } else if (this.srcParam.startsWith('file:')){
-      let resFile = fs.openSync(this.srcParam, fs.OpenMode.READ_ONLY)
-      this.src = `fd://${resFile.fd}`;
-    } else {
-      Logger.debug(TAG, `local, finalsrc: ${(this.src)}`);
-    }
+   // Logger.debug(TAG, `getFd, ${(this.src)}`);
   }
 
   onPageHide(): void {

--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -21,16 +21,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+import media from '@ohos.multimedia.media';
 import { VideoController } from '../controller/VideoController';
 import { CommonConstants } from '../common/constants/CommonConstants';
 import { PlayConstants } from '../common/constants/PlayConstants';
 import Logger from '../common/util/Logger';
 import Matrix4 from '@ohos.matrix4'
 import mediaquery from '@ohos.mediaquery'
+import fs from '@ohos.file.fs';
 
 export interface IPlayPlayer {
-  src: string
   muted: boolean
   repeat: boolean
   paused: boolean
@@ -53,7 +53,7 @@ const TAG: string = 'RNOH in ctrl'
 @Component
 export struct PlayPlayer {
   private playVideoModel: VideoController | undefined = undefined;
-  @Consume('srcVar') @Watch("onSrcChanged") src: string;// 视频src
+  @Consume('srcVar') @Watch("onSrcChanged") srcParam: string;// 视频src
   @Consume index: number;
   @Consume('mutedVar')  @Watch("onMutedChanged") muted: boolean ;
   @Consume('repeatVar') @Watch("onRepeatChanged") repeat: boolean;
@@ -65,6 +65,7 @@ export struct PlayPlayer {
   @Consume @Watch("onChanged") changedViewHeight: number;
   @Consume('preventsDisplaySleepDuringVideoPlaybackVar') @Watch("setPreventsDisplaySleepDuringVideoPlaybackModifier") preventsDisplaySleepDuringVideoPlayback: boolean;
 
+  @Provide type: number = CommonConstants.TYPE_LOCAL ;//TODO:luoxf 修改td
   @State bright: number = PlayConstants.PLAY_PAGE.BRIGHT;
   /* 不需要显示 */
   @State volumeShow: boolean = PlayConstants.PLAY_PAGE.VOLUME_SHOW;
@@ -101,21 +102,36 @@ export struct PlayPlayer {
 
   // @Watch cb
   onChanged(propName: string) : void {
-    Logger.debug(TAG, `onChanged,propName= ${JSON.stringify(propName)}`);
-    Logger.debug(TAG, `onChanged,volume= ${JSON.stringify(this.volume)}`);
-    Logger.debug(TAG, `onChanged,resizeMode= ${JSON.stringify(this.resizeMode)}`);
-    Logger.debug(TAG, `onChanged,disableFocus= ${JSON.stringify(this.disableFocus)}`);
     if (this.playVideoModel) {
       this.playVideoModel.updateProp();
     }
   }
 
-  onSrcChanged(propName: string) : void {
-    Logger.debug(TAG, `onSrcChanged,srcout: ${JSON.stringify(this.src)}`);
-    Logger.debug(TAG, `onSrcChanged,propName: ${JSON.stringify(propName)}`);
-    if (this.playVideoModel) {
-      this.playVideoModel.switchVideo(this.src);
+  async preparePlayer(): Promise<string | media.AVFileDescriptor> {
+    let  src:string | media.AVFileDescriptor = '';
+    if (this.srcParam.startsWith('http')) {
+      this.type = CommonConstants.TYPE_INTERNET
+      src = this.srcParam
+    } else if(this.srcParam.startsWith('asset')) {
+      const fileUrl = this.srcParam.split('//')[1];
+      let fileDescriptor = await getContext(this).resourceManager.getRawFd(`assets/${fileUrl}`);
+      src = fileDescriptor;
+    } else if (this.srcParam.startsWith('file:')){
+      let resFile = fs.openSync(this.srcParam, fs.OpenMode.READ_ONLY)
+      src = `fd://${resFile.fd}`;
+    } else {
+      Logger.debug(TAG, `local, finalsrc: ${(src)}`);
     }
+    return src
+  }
+
+  onSrcChanged(propName: string) : void {
+    Logger.debug(TAG, `onSrcChanged,propName: ${JSON.stringify(propName)}`);
+    this.preparePlayer().then((src)=>{
+      if (this.playVideoModel) {
+        this.playVideoModel.switchVideo(src);
+      }
+    })
   }
 
   onRepeatChanged(propName: string) : void {
@@ -153,6 +169,8 @@ export struct PlayPlayer {
   }
 
 
+
+
   build() {
     Column() {
       XComponent({
@@ -167,9 +185,12 @@ export struct PlayPlayer {
             surfaceHeight: PlayConstants.PLAY_PLAYER.SURFACE_HEIGHT
           });
           this.surfaceID = Number(this.xComponentController.getXComponentSurfaceId());
-          if (this.playVideoModel) {
-            this.playVideoModel.firstPlay(this.index, this.src, this.surfaceID);
-          }
+          this.preparePlayer().then((src)=>{
+            if (this.playVideoModel) {
+              this.playVideoModel.firstPlay(this.index, src, this.surfaceID);
+            }
+          })
+
         })
         .width(this.videoWidth)
         .height(this.videoHeight)


### PR DESCRIPTION


# Summary

修改react-native-video的本地视频暂停在播放是重头播放问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)


