### PR TITLE
fix: 开启repeat后将进度条汇至第一帧

### DIFF
--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -340,7 +340,22 @@ export struct PlayPlayer {
             .width(this.sliderWidth)
             .margin({ left: 5 })
             .onChange((value: number, mode: SliderChangeMode) => {
-              setTimeout(() => this.playVideoModel?.setSeekTime(value), 100);
+              let seekValue: number = value
+              if(this.repeat && value == this.duration)
+              {
+                return
+              }
+              if(this.repeat == false && value == this.duration){
+                seekValue = 0
+                this.startSecond = seekValue
+                this.playVideoModel?.setSeekTime(seekValue)
+                this.paused = true
+                return
+              }
+              // 修复循环播放时卡在最后一帧
+              setTimeout(
+                () => this.playVideoModel?.setSeekTime(seekValue)
+                , 100);
             })
 
           Text(this.formatSecondsToString(this.duration))


### PR DESCRIPTION


# Summary
fix: 开启repeat后将进度条汇至第一帧
## Test Plan
设置repeat为true，观察进度条是否重置

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
