### PR TITLE
fix: 修复observer.off 注销无感监听没有Callback 会把所有的都给注销，这里增加了Callback 只注销当前库

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -90,18 +90,13 @@ export interface IRNCVideo {
   onVideoEnd: () => void
   onVideoError: (err: string) => void
 }
-
 const TAG: string = 'RNOH in RNCVideo'
-
-
 @Component
 export struct RNCVideo {
   ctx!: RNOHContext;
   tag: number = -1;
   @State descriptor: VideoViewDescriptor = Object() as VideoViewDescriptor;
-  private callbackList: Array<() => void> = []
   @State videoMargin: string = PlayConstants.PLAY_PAGE.MARGIN_ZERO;
-  private playVideoModel: VideoController = new VideoController();
   @Provide('controlsVar') controls: boolean = false;
   @Provide('srcVar') srcParam: string | media.AVFileDescriptor = ''; /*最终avplayer认识的 字符串*/
   @Provide index: number = 0;
@@ -113,7 +108,6 @@ export struct RNCVideo {
   @Provide('disableFocusVar') disableFocus: boolean = false; /* RN侧默认是独占模式传递FALSE过来，鸿蒙默认未共享模式*/
   @Provide('preventsDisplaySleepDuringVideoPlaybackVar') preventsDisplaySleepDuringVideoPlayback: boolean =
     true; /* 默认true*/
-  private isResume: boolean = false;
   @State
   viewWidth: number = 0;
   @State
@@ -132,6 +126,9 @@ export struct RNCVideo {
   startSecond: number = 0
   @Provide
   duration: number = 0
+  private callbackList: Array<() => void> = []
+  private playVideoModel: VideoController = new VideoController();
+  private isResume: boolean = false;
 
   aboutToAppear(): void {
 
@@ -166,32 +163,15 @@ export struct RNCVideo {
       }
     })
     )
-
-    observer.on('navDestinationUpdate', (info) => {
-      let navDestinationInfo = JSON.stringify(info)
-      let navDestinationState = JSON.parse(navDestinationInfo) as NavDestinationState
-      let state = navDestinationState.state
-      let index = navDestinationState.index
-      //index 是 Navigation 的页面值  video 当前的页面 == 1, state表示当前页面的状态,ON_HIDDEN 为页面隐藏,ON_SHOWN为页面显示
-      if ((index == 1 || index == 0) && state == observer.NavDestinationState.ON_HIDDEN) {
-        this.paused = true
-      }
-      if ((index == 1 || index == 0) && state == observer.NavDestinationState.ON_SHOWN) {
-        if (this.isUserPaused) {
-          this.paused = true
-        } else {
-          this.paused = false
-        }
-
-      }
-    });
-
+    //注册 navDestinationCallback
+    observer.on('navDestinationUpdate', this.navDestinationCallback);
   }
 
   aboutToDisappear(): void {
     this.cancellationCallback()
     this.playVideoModel.release();
-    observer.off('navDestinationUpdate');
+    //销毁 navDestinationCallback
+    observer.off('navDestinationUpdate', this.navDestinationCallback);
   }
 
   registerCommandCallback(): void {
@@ -257,9 +237,8 @@ export struct RNCVideo {
   }
 
   onVideoEnd(): void {
-    if(this.repeat == undefined || this.repeat == false)
-    {
-        this.paused = true
+    if (this.repeat == undefined || this.repeat == false) {
+      this.paused = true
     }
     if (this.ctx) {
       this.ctx.rnInstance.emitComponentEvent(this.descriptor.tag, RNC_VIDEO_TYPE, {
@@ -364,6 +343,25 @@ export struct RNCVideo {
         .align(Alignment.Center)
         .height(this.viewHeight)
         .width(this.viewWidth)
+    }
+  }
+
+  private navDestinationCallback: Callback<NavDestinationInfo> = (info) => {
+    let navDestinationInfo = JSON.stringify(info)
+    let navDestinationState = JSON.parse(navDestinationInfo) as NavDestinationState
+    let state = navDestinationState.state
+    let index = navDestinationState.index
+    //index 是 Navigation 的页面值  video 当前的页面 == 1, state表示当前页面的状态,ON_HIDDEN 为页面隐藏,ON_SHOWN为页面显示
+    if ((index == 1 || index == 0) && state == observer.NavDestinationState.ON_HIDDEN) {
+      this.paused = true
+    }
+    if ((index == 1 || index == 0) && state == observer.NavDestinationState.ON_SHOWN) {
+      if (this.isUserPaused) {
+        this.paused = true
+      } else {
+        this.paused = false
+      }
+
     }
   }
 }


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 修复observer.off 注销无感监听没有Callback 会把所有的都给注销，这里增加了Callback 只注销当前库 #104 

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
