### PR TITLE
fix:修复onReadyForDisplay重复回调问题&全屏打开关闭回调问题

### DIFF
--- a/harmony/rn_video/src/main/ets/RNCVideo.ets
+++ b/harmony/rn_video/src/main/ets/RNCVideo.ets
@@ -203,11 +203,6 @@ export struct RNCVideo {
     case EventType.SETLICENSERESULTERRORCMD:
       break;
     case EventType.SETFULLSCREENCMD:
-      if (this.fullscreen) {
-        this.onVideoFullscreenPlayerWillPresent()
-      } else {
-        this.onVideoFullscreenPlayerWillDismiss()
-      }
       this.playVideoModel.pipManager.stopPip()
 
       const _fullscreen: boolean = eventData.data?.fullScreen;

--- a/harmony/rn_video/src/main/ets/controller/VideoController.ets
+++ b/harmony/rn_video/src/main/ets/controller/VideoController.ets
@@ -320,7 +320,6 @@ export class VideoController {
           this.pipManager.init(getContext(this))
           break;
         case AvplayerStatus.PLAYING:
-          this.onReadyForDisplay();
           this.status = CommonConstants.STATUS_START;
           this.playPageThis.onVideoPlaybackStateChanged(true, this.isSeeking);
           this.watchStatus();

--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -282,6 +282,7 @@ export struct PlayPlayer {
     if(this.fullscreen == true)
     {
       if (this.dialogController != null) {
+        this.playVideoModel?.playPageThis.onVideoFullscreenPlayerWillPresent();
         this.videoSrc = this.srcParam
         this.videoResizeMode = this.resizeMode
         this.startTime = this.startSecond
@@ -290,6 +291,7 @@ export struct PlayPlayer {
         this.playVideoModel?.playPageThis.onVideoFullscreenPlayerDidPresent();
       }
     } else {
+      this.playVideoModel?.playPageThis?.onVideoFullscreenPlayerWillDismiss();
       this.setModalVisible(false)
       this.playVideoModel?.playPageThis?.onVideoFullscreenPlayerDidDismiss();
     }


### PR DESCRIPTION
# Summary

- fix:修复onReadyForDisplay重复回调问题&全屏打开关闭回调问题。

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

<img width="590" height="1279" alt="image" src="https://github.com/user-attachments/assets/f3c93dfd-b264-47f2-b770-3489a13533ef" />


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
