### PR TITLE
fix:修改当全屏播放视频时，底部有留白的问题

### DIFF
--- a/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
+++ b/harmony/rn_video/src/main/ets/view/PlayPlayer.ets
@@ -154,7 +154,7 @@ export struct PlayPlayer {
       }
     },
     alignment: DialogAlignment.Bottom,
-    offset: { dx: 0, dy: -20 },
+    offset: { dx: 0, dy: 0 },
     gridCount: 4,
     customStyle: true,
     cornerRadius: 0,


### PR DESCRIPTION
# Summary

- fix:修改当全屏播放视频时，底部有留白的问题。

## Test Plan

<img width="2736" height="3648" alt="image" src="https://github.com/user-attachments/assets/56e06ceb-6446-4add-b31f-9af771815112" />


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
